### PR TITLE
fix: PC 화면에서 아이템 카드 너비 확장

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
         }
         #grid-container {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+            grid-template-columns: repeat(auto-fill, minmax(440px, 1fr));
             gap: 20px;
         }
         .item-card {


### PR DESCRIPTION
PC와 같이 넓은 화면에서 아이템 이름이 잘리는 문제를 해결하기 위해 아이템 카드의 최소 너비를 조정합니다.

- `index.html`의 `#grid-container` CSS 규칙에서 `minmax` 값을 `220px`에서 `440px`로 변경하여, 사용자의 요청대로 카드 너비가 약 2배가 되도록 수정했습니다.
- 이를 통해 넓은 화면에서 한 줄에 표시되는 열의 수가 줄어들고, 각 카드의 너비가 확보되어 콘텐츠가 잘리지 않게 됩니다.