### PR TITLE
fix: 미디어 쿼리를 사용하여 카드 너비 반응형으로 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,15 @@
         }
         #grid-container {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(440px, 1fr));
+            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
             gap: 20px;
+        }
+
+        /* For tablets and wider screens, make cards wider */
+        @media (min-width: 768px) {
+            #grid-container {
+                grid-template-columns: repeat(auto-fill, minmax(440px, 1fr));
+            }
         }
         .item-card {
             background-color: #2c2c2e;


### PR DESCRIPTION
PC 화면에서 카드 너비를 늘렸을 때 모바일 레이아웃이 깨지는 문제를 해결합니다.

- `#grid-container`의 기본 카드 최소 너비를 `220px`로 설정하여 모바일 화면에 최적화합니다.
- `@media (min-width: 768px)` 미디어 쿼리를 추가하여, 태블릿 및 PC와 같이 넓은 화면에서는 최소 너비를 `440px`로 늘려 PC 가독성을 확보합니다.
- 이를 통해 모바일과 PC에서 모두 최적의 레이아웃을 제공합니다.