### PR TITLE
feat: 카테고리별 가격 조회 및 등락 정보 표시 기능 구현

### DIFF
--- a/function.sql
+++ b/function.sql
@@ -1,3 +1,78 @@
+-- This is the new function that fetches prices by category and calculates price changes.
+CREATE
+OR
+REPLACE FUNCTION get_latest_prices_by_category(p_category_codes INTEGER[])
+RETURNS TABLE (
+    item_name TEXT,
+    icon_path TEXT,
+    grade TEXT,
+    price INTEGER,
+    last_updated TIMESTAMPTZ,
+    category_code INTEGER,
+    price_change INTEGER,
+    change_direction TEXT
+) AS $$
+BEGIN RETURN QUERY
+WITH latest_prices AS (
+    SELECT
+        p.item_id,
+        p.price,
+        p.timestamp
+    FROM (
+        SELECT
+            ph.item_id,
+            ph.price,
+            ph.timestamp,
+            ROW_NUMBER() OVER (PARTITION BY ph.item_id ORDER BY ph.timestamp DESC) as rn
+        FROM price_history ph
+        JOIN items i ON ph.item_id = i.id
+        WHERE i.category_code = ANY(p_category_codes)
+    ) p
+    WHERE p.rn = 1
+),
+prev_day_prices AS (
+    SELECT
+        p.item_id,
+        p.price
+    FROM (
+        SELECT
+            ph.item_id,
+            ph.price,
+            ROW_NUMBER() OVER (PARTITION BY ph.item_id ORDER BY ph.timestamp DESC) as rn
+        FROM price_history ph
+        JOIN items i ON ph.item_id = i.id
+        WHERE i.category_code = ANY(p_category_codes)
+          AND ph.timestamp < date_trunc('day', now()) -- Before today
+    ) p
+    WHERE p.rn = 1
+)
+SELECT
+    i.item_name,
+    i.icon_path,
+    i.grade,
+    lp.price,
+    lp.timestamp AS last_updated,
+    i.category_code,
+    COALESCE(lp.price - pdp.price, 0) AS price_change,
+    CASE
+        WHEN pdp.price IS NULL THEN 'same'
+        WHEN lp.price > pdp.price THEN 'up'
+        WHEN lp.price < pdp.price THEN 'down'
+        ELSE 'same'
+    END AS change_direction
+FROM
+    items i
+JOIN
+    latest_prices lp ON i.id = lp.item_id
+LEFT JOIN
+    prev_day_prices pdp ON i.id = pdp.item_id
+WHERE
+    i.category_code = ANY(p_category_codes)
+ORDER BY
+    i.item_name;
+END;
+$$ LANGUAGE plpgsql;
+
 -- 각 아이템의 최신 가격 정보를 조회하는 데이터베이스 함수를 생성합니다.
 -- 이 함수를 사용하면 웹페이지에서 훨씬 빠르고 효율적으로 데이터를 불러올 수 있습니다.
 CREATE

--- a/style.css
+++ b/style.css
@@ -141,6 +141,11 @@ p.description {
     font-size: 0.75rem;
     color: #8e8e93;
 }
+.price-container {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+}
 .item-price {
     font-size: 1rem;
     font-weight: bold;
@@ -149,6 +154,16 @@ p.description {
 }
 .item-price::before {
     content: '💰 ';
+}
+.price-change {
+    font-size: 0.8rem;
+    margin-top: 4px;
+}
+.price-change.up {
+    color: #ff4d4f; /* A nice red */
+}
+.price-change.down {
+    color: #4d94ff; /* A nice blue */
 }
 .last-updated {
     font-size: 0.75rem;


### PR DESCRIPTION
- 데이터베이스 함수 `get_latest_prices_by_category`를 새로 추가하여 카테고리별로 아이템 가격을 효율적으로 조회하도록 변경
- 전일 마지막 가격과 비교하여 가격 변동 및 등락 상태를 계산하는 로직을 데이터베이스 함수에 포함
- `script.js`를 수정하여 새로운 데이터베이스 함수를 호출하고, 클라이언트 측 필터링 로직을 제거
- `renderItems` 함수를 수정하여 가격 등락 정보를 UI에 렌더링하도록 변경
- `style.css`에 등락 상태(상승/하락)에 따른 색상 및 스타일 규칙 추가