### PR TITLE
기능: 아이템 상세 정보 페이지 구현

### DIFF
--- a/detail.html
+++ b/detail.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>아이템 상세 정보</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- Chart.js CDN -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+    <main>
+        <h1 id="item-name-title">아이템 정보</h1>
+        <div class="filters">
+            <a href="index.html" class="nav-button">메인으로</a>
+            <a href="#" id="back-to-list" class="nav-button">목록으로</a>
+        </div>
+        <div id="item-detail-container">
+            <!-- 아이템 상세 정보가 여기에 동적으로 채워집니다. -->
+        </div>
+        <div class="chart-container">
+            <canvas id="price-chart"></canvas>
+        </div>
+    </main>
+
+    <script type="module" src="detail.js" defer></script>
+</body>
+</html>

--- a/detail.js
+++ b/detail.js
@@ -1,0 +1,164 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+
+const SUPABASE_URL = 'https://ojyiduiquzldbnimulvp.supabase.co';
+const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9qeWlkdWlxdXpsZGJuaW11bHZwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc2MzkxMTIsImV4cCI6MjA3MzIxNTExMn0.VRNMrbQSXZtWLPNuW-Sn522G1pmhT4AkhX0RJgANqZ4';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+const itemNameTitle = document.getElementById('item-name-title');
+const itemDetailContainer = document.getElementById('item-detail-container');
+const backToListBtn = document.getElementById('back-to-list');
+const priceChartCanvas = document.getElementById('price-chart');
+
+const gradeColors = {
+    "일반": "#a5a5a5",
+    "고급": "#6bbd00",
+    "희귀": "#00b0fa",
+    "영웅": "#ba00f9",
+    "전설": "#f99200",
+    "유물": "#fa5d00",
+    "고대": "#B3956C",
+    "에스더": "#14c5b9"
+};
+
+const categoryMap = {
+    "10000": "engraving.html",
+    "210000": "engraving.html",
+    "refining": "honing.html",
+    "50010": "honing.html",
+    "50020": "honing.html",
+    "220000": "jewels.html",
+    "230000": "gems.html"
+};
+
+function getCategoryPage(categoryCode) {
+    if (!categoryCode) return "index.html";
+    return categoryMap[categoryCode] || "index.html";
+}
+
+async function loadItemDetails() {
+    const params = new URLSearchParams(window.location.search);
+    const itemName = params.get('itemName');
+    const category = params.get('category');
+
+    if (!itemName) {
+        itemDetailContainer.innerHTML = '<p>아이템 이름을 찾을 수 없습니다.</p>';
+        return;
+    }
+
+    // Set the "Back to List" button link
+    const listPage = getCategoryPage(category);
+    backToListBtn.href = listPage;
+
+    try {
+        // Fetch item details
+        const { data: itemData, error: itemError } = await supabase
+            .rpc('get_item_details', { p_item_name: itemName })
+            .single();
+
+        if (itemError) throw itemError;
+        if (!itemData) {
+            itemDetailContainer.innerHTML = '<p>아이템 정보를 불러오는 데 실패했습니다.</p>';
+            return;
+        }
+
+        renderItemDetails(itemData);
+
+        // Fetch price history
+        const { data: historyData, error: historyError } = await supabase
+            .rpc('get_item_price_history', { p_item_name: itemName });
+
+        if (historyError) throw historyError;
+
+        renderPriceChart(historyData);
+
+    } catch (error) {
+        console.error('Error loading item data:', error);
+        itemDetailContainer.innerHTML = `<p>데이터 로딩 중 오류 발생: ${error.message}</p>`;
+    }
+}
+
+function renderItemDetails(item) {
+    itemNameTitle.textContent = item.item_name;
+
+    const formattedPrice = item.price.toLocaleString('ko-KR');
+    const formattedDate = new Date(item.last_updated).toLocaleString('ko-KR', {
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', hour12: false
+    });
+    const itemColor = gradeColors[item.grade] || '#f2f2f7';
+
+    itemDetailContainer.innerHTML = `
+        <div class="item-card-detail">
+            <div class="card-top-row">
+                <div class="card-top-left">
+                    <img class="item-icon" src="${item.icon_path}" alt="${item.item_name} 아이콘" onerror="this.style.display='none'"/>
+                    <div class="item-details">
+                        <div class="item-name" title="${item.item_name}" style="color: ${itemColor};">${item.item_name}</div>
+                    </div>
+                </div>
+                <div class="price-container">
+                    <div class="item-price">${formattedPrice}</div>
+                </div>
+            </div>
+            <div class="last-updated">${formattedDate}</div>
+        </div>
+    `;
+}
+
+function renderPriceChart(historyData) {
+    if (!historyData || historyData.length === 0) {
+        priceChartCanvas.style.display = 'none';
+        return;
+    }
+
+    const labels = historyData.map(d => new Date(d.history_date).toLocaleDateString('ko-KR', { month: '2-digit', day: '2-digit' }));
+    const prices = historyData.map(d => d.closing_price);
+
+    new Chart(priceChartCanvas, {
+        type: 'line',
+        data: {
+            labels: labels,
+            datasets: [{
+                label: '일자별 마감 시세 (골드)',
+                data: prices,
+                borderColor: '#007bff',
+                backgroundColor: 'rgba(0, 123, 255, 0.1)',
+                fill: true,
+                tension: 0.1
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                y: {
+                    beginAtZero: false,
+                    ticks: {
+                        callback: function(value, index, values) {
+                            return value.toLocaleString('ko-KR');
+                        }
+                    }
+                }
+            },
+            plugins: {
+                tooltip: {
+                    callbacks: {
+                        label: function(context) {
+                            let label = context.dataset.label || '';
+                            if (label) {
+                                label += ': ';
+                            }
+                            if (context.parsed.y !== null) {
+                                label += context.parsed.y.toLocaleString('ko-KR') + ' 골드';
+                            }
+                            return label;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+loadItemDetails();

--- a/script.js
+++ b/script.js
@@ -48,6 +48,12 @@ if (gridContainer) {
         }
 
         currentItems.forEach(item => {
+            const pageCategory = document.body.dataset.pageCategory;
+
+            const link = document.createElement('a');
+            link.className = 'item-link';
+            link.href = `detail.html?itemName=${encodeURIComponent(item.item_name)}&category=${pageCategory}`;
+
             const card = document.createElement('div');
             card.className = 'item-card';
 
@@ -82,7 +88,8 @@ if (gridContainer) {
                 </div>
                 <div class="last-updated">${formattedDate}</div>
             `;
-            gridContainer.appendChild(card);
+            link.appendChild(card);
+            gridContainer.appendChild(link);
         });
     }
 

--- a/style.css
+++ b/style.css
@@ -260,3 +260,28 @@ p.description {
 #result-table tr:last-child td {
     border-bottom: none;
 }
+
+/* Make item cards proper links */
+.item-link {
+    text-decoration: none;
+    color: inherit;
+    display: block; /* Ensures the link takes up the full grid cell space */
+}
+
+/* Detail Page Specific Styles */
+.item-card-detail {
+    background-color: #2c2c2e;
+    border-radius: 12px;
+    padding: 16px;
+    margin-bottom: 24px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+}
+
+.chart-container {
+    background-color: #2c2c2e;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    height: 400px; /* Give the chart a fixed height */
+    max-height: 60vh; /* Ensure it doesn't take up too much vertical space */
+}


### PR DESCRIPTION
사용자가 목록에서 아이템을 클릭했을 때, 해당 아이템의 상세 정보를 볼 수 있는 페이지를 구현했습니다.

주요 변경 사항:
- 아이템 상세 정보와 일별 시세 차트를 표시하는 상세 페이지(`detail.html`, `detail.js`)를 추가했습니다.
- Chart.js 라이브러리를 사용하여 시세 변동을 시각화했습니다.
- 특정 아이템의 정보와 가격 기록을 조회하기 위한 새로운 데이터베이스 함수(`get_item_details`, `get_item_price_history`)를 `function.sql`에 추가했습니다.
- 기존 목록 페이지(`script.js`)의 아이템 카드에 상세 페이지로 이동하는 링크를 추가했습니다.
- 상세 페이지 레이아웃과 차트 표시를 위한 스타일을 `style.css`에 추가했습니다.