### PR TITLE
수정: 아이템 상세 페이지 버그 수정

### DIFF
--- a/detail.js
+++ b/detail.js
@@ -21,13 +21,11 @@ const gradeColors = {
     "에스더": "#14c5b9"
 };
 
+// Corrected and simplified category map
 const categoryMap = {
-    "10000": "engraving.html",
-    "210000": "engraving.html",
+    "40000": "engraving.html",
     "refining": "honing.html",
-    "50010": "honing.html",
-    "50020": "honing.html",
-    "220000": "jewels.html",
+    "210000": "jewels.html",
     "230000": "gems.html"
 };
 
@@ -38,11 +36,11 @@ function getCategoryPage(categoryCode) {
 
 async function loadItemDetails() {
     const params = new URLSearchParams(window.location.search);
-    const itemName = params.get('itemName');
+    const itemId = params.get('itemId');
     const category = params.get('category');
 
-    if (!itemName) {
-        itemDetailContainer.innerHTML = '<p>아이템 이름을 찾을 수 없습니다.</p>';
+    if (!itemId) {
+        itemDetailContainer.innerHTML = '<p>아이템 ID를 찾을 수 없습니다.</p>';
         return;
     }
 
@@ -51,9 +49,9 @@ async function loadItemDetails() {
     backToListBtn.href = listPage;
 
     try {
-        // Fetch item details
+        // Fetch item details by ID
         const { data: itemData, error: itemError } = await supabase
-            .rpc('get_item_details', { p_item_name: itemName })
+            .rpc('get_item_details_by_id', { p_item_id: itemId })
             .single();
 
         if (itemError) throw itemError;
@@ -64,9 +62,9 @@ async function loadItemDetails() {
 
         renderItemDetails(itemData);
 
-        // Fetch price history
+        // Fetch price history by ID
         const { data: historyData, error: historyError } = await supabase
-            .rpc('get_item_price_history', { p_item_name: itemName });
+            .rpc('get_item_price_history_by_id', { p_item_id: itemId });
 
         if (historyError) throw historyError;
 

--- a/function.sql
+++ b/function.sql
@@ -1,8 +1,8 @@
 -- This is the new function that fetches prices by category and calculates price changes.
-CREATE
-OR
-REPLACE FUNCTION get_latest_prices_by_category(p_category_codes INTEGER[])
+-- Now returns item_id as well.
+CREATE OR REPLACE FUNCTION get_latest_prices_by_category(p_category_codes INTEGER[])
 RETURNS TABLE (
+    item_id BIGINT,
     item_name TEXT,
     icon_path TEXT,
     grade TEXT,
@@ -12,72 +12,72 @@ RETURNS TABLE (
     price_change INTEGER,
     change_direction TEXT
 ) AS $$
-BEGIN RETURN QUERY
-WITH latest_prices AS (
-    SELECT
-        p.item_id,
-        p.price,
-        p.timestamp
-    FROM (
+BEGIN
+    RETURN QUERY
+    WITH latest_prices AS (
         SELECT
-            ph.item_id,
-            ph.price,
-            ph.timestamp,
-            ROW_NUMBER() OVER (PARTITION BY ph.item_id ORDER BY ph.timestamp DESC) as rn
-        FROM price_history ph
-        JOIN items i ON ph.item_id = i.id
-        WHERE i.category_code = ANY(p_category_codes)
-    ) p
-    WHERE p.rn = 1
-),
-prev_day_prices AS (
-    SELECT
-        p.item_id,
-        p.price
-    FROM (
+            p.item_id,
+            p.price,
+            p.timestamp
+        FROM (
+            SELECT
+                ph.item_id,
+                ph.price,
+                ph.timestamp,
+                ROW_NUMBER() OVER (PARTITION BY ph.item_id ORDER BY ph.timestamp DESC) as rn
+            FROM price_history ph
+            JOIN items i ON ph.item_id = i.id
+            WHERE i.category_code = ANY(p_category_codes)
+        ) p
+        WHERE p.rn = 1
+    ),
+    prev_day_prices AS (
         SELECT
-            ph.item_id,
-            ph.price,
-            ROW_NUMBER() OVER (PARTITION BY ph.item_id ORDER BY ph.timestamp DESC) as rn
-        FROM price_history ph
-        JOIN items i ON ph.item_id = i.id
-        WHERE i.category_code = ANY(p_category_codes)
-          AND ph.timestamp < date_trunc('day', now()) -- Before today
-    ) p
-    WHERE p.rn = 1
-)
-SELECT
-    i.item_name,
-    i.icon_path,
-    i.grade,
-    lp.price,
-    lp.timestamp AS last_updated,
-    i.category_code,
-    COALESCE(lp.price - pdp.price, 0) AS price_change,
-    CASE
-        WHEN pdp.price IS NULL THEN 'same'
-        WHEN lp.price > pdp.price THEN 'up'
-        WHEN lp.price < pdp.price THEN 'down'
-        ELSE 'same'
-    END AS change_direction
-FROM
-    items i
-JOIN
-    latest_prices lp ON i.id = lp.item_id
-LEFT JOIN
-    prev_day_prices pdp ON i.id = pdp.item_id
-WHERE
-    i.category_code = ANY(p_category_codes)
-ORDER BY
-    i.item_name;
+            p.item_id,
+            p.price
+        FROM (
+            SELECT
+                ph.item_id,
+                ph.price,
+                ROW_NUMBER() OVER (PARTITION BY ph.item_id ORDER BY ph.timestamp DESC) as rn
+            FROM price_history ph
+            JOIN items i ON ph.item_id = i.id
+            WHERE i.category_code = ANY(p_category_codes)
+              AND ph.timestamp < date_trunc('day', now()) -- Before today
+        ) p
+        WHERE p.rn = 1
+    )
+    SELECT
+        i.id AS item_id,
+        i.item_name,
+        i.icon_path,
+        i.grade,
+        lp.price,
+        lp.timestamp AS last_updated,
+        i.category_code,
+        COALESCE(lp.price - pdp.price, 0) AS price_change,
+        CASE
+            WHEN pdp.price IS NULL THEN 'same'
+            WHEN lp.price > pdp.price THEN 'up'
+            WHEN lp.price < pdp.price THEN 'down'
+            ELSE 'same'
+        END AS change_direction
+    FROM
+        items i
+    JOIN
+        latest_prices lp ON i.id = lp.item_id
+    LEFT JOIN
+        prev_day_prices pdp ON i.id = pdp.item_id
+    WHERE
+        i.category_code = ANY(p_category_codes)
+    ORDER BY
+        i.item_name;
 END;
 $$ LANGUAGE plpgsql;
 
 -- 각 아이템의 최신 가격 정보를 조회하는 데이터베이스 함수를 생성합니다.
 -- 이 함수를 사용하면 웹페이지에서 훨씬 빠르고 효율적으로 데이터를 불러올 수 있습니다.
-CREATE
-OR
-REPLACE FUNCTION get_latest_prices()
+CREATE OR REPLACE FUNCTION get_latest_prices()
 RETURNS TABLE (
     item_name TEXT,
     icon_path TEXT,
@@ -86,27 +86,29 @@ RETURNS TABLE (
     last_updated TIMESTAMPTZ,
     category_code INTEGER
 ) AS $$
-BEGIN RETURN QUERY
-SELECT i.item_name,
-       i.icon_path,
-       i.grade,
-       p.price,
-       p.timestamp AS last_updated,
-       i.category_code
-FROM items i
-         JOIN
-     (SELECT ph.item_id,
-             ph.price,
-             ph.timestamp,
-             ROW_NUMBER() OVER (PARTITION BY ph.item_id ORDER BY ph.timestamp DESC) as rn
-      FROM price_history ph) p ON i.id = p.item_id
-WHERE p.rn = 1
-ORDER BY i.item_name;
+BEGIN
+    RETURN QUERY
+    SELECT i.item_name,
+           i.icon_path,
+           i.grade,
+           p.price,
+           p.timestamp AS last_updated,
+           i.category_code
+    FROM items i
+    JOIN (
+        SELECT ph.item_id,
+               ph.price,
+               ph.timestamp,
+               ROW_NUMBER() OVER (PARTITION BY ph.item_id ORDER BY ph.timestamp DESC) as rn
+        FROM price_history ph
+    ) p ON i.id = p.item_id
+    WHERE p.rn = 1
+    ORDER BY i.item_name;
 END;
 $$ LANGUAGE plpgsql;
 
--- 특정 아이템의 최신 정보와 가격을 조회하는 함수
-CREATE OR REPLACE FUNCTION get_item_details(p_item_name TEXT)
+-- 특정 아이템의 최신 정보와 가격을 ID로 조회하는 함수
+CREATE OR REPLACE FUNCTION get_item_details_by_id(p_item_id BIGINT)
 RETURNS TABLE (
     item_name TEXT,
     icon_path TEXT,
@@ -133,12 +135,12 @@ BEGIN
             ROW_NUMBER() OVER(PARTITION BY ph.item_id ORDER BY ph.timestamp DESC) as rn
         FROM price_history ph
     ) p ON i.id = p.item_id
-    WHERE p.rn = 1 AND i.item_name = p_item_name;
+    WHERE p.rn = 1 AND i.id = p_item_id;
 END;
 $$ LANGUAGE plpgsql;
 
--- 특정 아이템의 일자별 마지막 가격을 조회하는 함수 (최근 30일)
-CREATE OR REPLACE FUNCTION get_item_price_history(p_item_name TEXT)
+-- 특정 아이템의 일자별 마지막 가격을 ID로 조회하는 함수 (최근 30일)
+CREATE OR REPLACE FUNCTION get_item_price_history_by_id(p_item_id BIGINT)
 RETURNS TABLE (
     history_date DATE,
     closing_price INTEGER
@@ -152,7 +154,7 @@ BEGIN
             ROW_NUMBER() OVER(PARTITION BY (ph.timestamp AT TIME ZONE 'Asia/Seoul')::DATE ORDER BY ph.timestamp DESC) as rn
         FROM price_history ph
         JOIN items i ON ph.item_id = i.id
-        WHERE i.item_name = p_item_name
+        WHERE i.id = p_item_id
           AND ph.timestamp >= NOW() - INTERVAL '30 days'
     )
     SELECT

--- a/script.js
+++ b/script.js
@@ -52,7 +52,7 @@ if (gridContainer) {
 
             const link = document.createElement('a');
             link.className = 'item-link';
-            link.href = `detail.html?itemName=${encodeURIComponent(item.item_name)}&category=${pageCategory}`;
+            link.href = `detail.html?itemId=${item.item_id}&category=${pageCategory}`;
 
             const card = document.createElement('div');
             card.className = 'item-card';


### PR DESCRIPTION
사용자 피드백을 반영하여 상세 페이지의 두 가지 주요 버그를 수정했습니다.

1.  **ID 기반 조회로 변경:**
    *   '젬'과 같이 이름이 중복될 수 있는 아이템을 정확히 식별하기 위해, 아이템 이름(`itemName`) 대신 고유 ID(`itemId`)를 사용하여 상세 정보를 조회하도록 로직을 전면 수정했습니다.
    *   `function.sql`, `script.js`, `detail.js` 파일이 모두 `itemId`를 사용하도록 변경되었습니다.

2.  **'목록으로' 버튼 네비게이션 오류 수정:**
    *   상세 페이지에서 '목록으로' 버튼 클릭 시, 이전에 보던 카테고리 목록으로 정확히 돌아가지 않던 문제를 해결했습니다.
    *   `detail.js`의 `categoryMap`을 실제 `data-page-category` 값과 일치하도록 수정하여 네비게이션 로직을 바로잡았습니다.