### PR TITLE
수정: 상세 페이지 차트 표시 방법 변경

### DIFF
--- a/detail.html
+++ b/detail.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" href="style.css">
     <!-- Chart.js CDN -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <!-- Chart.js Datalabels Plugin for displaying values on the chart -->
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0/dist/chartjs-plugin-datalabels.min.js"></script>
 </head>
 <body>
     <main>

--- a/detail.js
+++ b/detail.js
@@ -113,12 +113,14 @@ function renderPriceChart(historyData) {
     const labels = historyData.map(d => new Date(d.history_date).toLocaleDateString('ko-KR', { month: '2-digit', day: '2-digit' }));
     const prices = historyData.map(d => d.closing_price);
 
+    // Register the datalabels plugin
+    Chart.register(ChartDataLabels);
+
     new Chart(priceChartCanvas, {
         type: 'line',
         data: {
             labels: labels,
             datasets: [{
-                label: '일자별 마감 시세 (골드)',
                 data: prices,
                 borderColor: '#007bff',
                 backgroundColor: 'rgba(0, 123, 255, 0.1)',
@@ -140,18 +142,34 @@ function renderPriceChart(historyData) {
                 }
             },
             plugins: {
+                // Hide the default legend
+                legend: {
+                    display: false
+                },
                 tooltip: {
                     callbacks: {
                         label: function(context) {
-                            let label = context.dataset.label || '';
-                            if (label) {
-                                label += ': ';
-                            }
+                            let label = '가격: ';
                             if (context.parsed.y !== null) {
                                 label += context.parsed.y.toLocaleString('ko-KR') + ' 골드';
                             }
                             return label;
                         }
+                    }
+                },
+                // Configure the datalabels plugin
+                datalabels: {
+                    align: 'end',
+                    anchor: 'end',
+                    color: '#e0e0e0',
+                    font: {
+                        weight: 'bold'
+                    },
+                    formatter: function(value, context) {
+                        return value.toLocaleString('ko-KR');
+                    },
+                    padding: {
+                        top: 4
                     }
                 }
             }


### PR DESCRIPTION
사용자 피드백에 따라 상세 페이지의 가격 변동 차트 표시 방법을 다음과 같이 수정했습니다.

- 차트 상단의 범례('일자별 마감 시세 (골드)')를 제거하여 차트 영역을 더 깔끔하게 만들었습니다.
- `chartjs-plugin-datalabels` 플러그인을 추가하여, 각 데이터 포인트에 마우스를 올리지 않아도 항상 가격이 표시되도록 개선했습니다.