### PR TITLE
fix: KST 시간대 기준으로 어제 가격을 계산하도록 수정

### DIFF
--- a/function.sql
+++ b/function.sql
@@ -43,7 +43,7 @@ BEGIN
             FROM price_history ph
             JOIN items i ON ph.item_id = i.id
             WHERE i.category_code = ANY(p_category_codes)
-              AND ph.timestamp < date_trunc('day', now()) -- Before today
+              AND ph.timestamp < (date_trunc('day', now() AT TIME ZONE 'Asia/Seoul') AT TIME ZONE 'Asia/Seoul') -- Before today (KST)
         ) p
         WHERE p.rn = 1
     )


### PR DESCRIPTION
기존에는 UTC 시간대 기준으로 전일 가격을 계산하여 한국 시간(KST) 기준으로는 가격 변동이 정확하지 않았습니다.

`function.sql` 파일의 `get_latest_prices_by_category` 함수에서 전일 마감 가격을 가져오는 로직을 수정했습니다. `now()` 함수에 KST 시간대를 적용하여, 한국 시간 기준으로 어제의 마지막 가격을 올바르게 가져오도록 변경했습니다.