### PR TITLE
feat: add cache busting to JS and CSS files

### DIFF
--- a/auction.html
+++ b/auction.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>경매 분배금 계산기</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=1757912465">
 </head>
 <body>
     <main>
@@ -40,7 +40,7 @@
             </div>
         </div>
     </main>
-    <script src="auction.js" type="module"></script>
+    <script src="auction.js?v=1757912465" type="module"></script>
     <!-- Toast Notification -->
     <div id="toast-popup" class="toast-popup">클립보드에 복사되었습니다.</div>
 </body>

--- a/detail.html
+++ b/detail.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>아이템 상세 정보</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=1757912465">
     <!-- Chart.js CDN -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- Chart.js Datalabels Plugin for displaying values on the chart -->
@@ -25,6 +25,6 @@
         </div>
     </main>
 
-    <script type="module" src="detail.js" defer></script>
+    <script type="module" src="detail.js?v=1757912465" defer></script>
 </body>
 </html>

--- a/engraving.html
+++ b/engraving.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>각인서 시세 정보</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=1757912465">
 </head>
 <body data-page-category="40000">
     <main>
@@ -17,6 +17,6 @@
         <div id="grid-container"></div>
     </main>
 
-    <script type="module" src="script.js" defer></script>
+    <script type="module" src="script.js?v=1757912465" defer></script>
 </body>
 </html>

--- a/gems.html
+++ b/gems.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>젬 시세 정보</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=1757912465">
 </head>
 <body data-page-category="230000">
     <main>
@@ -17,6 +17,6 @@
         <div id="grid-container"></div>
     </main>
 
-    <script type="module" src="script.js" defer></script>
+    <script type="module" src="script.js?v=1757912465" defer></script>
 </body>
 </html>

--- a/honing.html
+++ b/honing.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>재련 재료 시세 정보</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=1757912465">
 </head>
 <body data-page-category="refining">
     <main>
@@ -17,6 +17,6 @@
         <div id="grid-container"></div>
     </main>
 
-    <script type="module" src="script.js" defer></script>
+    <script type="module" src="script.js?v=1757912465" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>로스트아크 시세 정보</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=1757912465">
 </head>
 <body>
     <main>

--- a/jewels.html
+++ b/jewels.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>보석 시세 정보</title>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=1757912465">
 </head>
 <body data-page-category="210000">
     <main>
@@ -17,6 +17,6 @@
         <div id="grid-container"></div>
     </main>
 
-    <script type="module" src="script.js" defer></script>
+    <script type="module" src="script.js?v=1757912465" defer></script>
 </body>
 </html>


### PR DESCRIPTION
This change adds a cache-busting query string to all JavaScript and CSS includes in the HTML files. This prevents the browser from using cached versions of these files, ensuring that users always get the latest version.

A static timestamp is used as the query string. While this works for the immediate purpose, a more robust solution for the future would involve a build process that generates a unique hash for each file on every build.